### PR TITLE
Fix: Dependency location

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     implementation(project(":components:kafka"))
     implementation(project(":components:mqtt"))
 
+    implementation("org.springframework:spring-aspects")
+
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/components/kafka/build.gradle.kts
+++ b/components/kafka/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot-starter-logging")
 
-    implementation("org.springframework:spring-aspects")
     implementation("org.springframework:spring-aop")
 
     implementation("org.springframework.kafka:spring-kafka")


### PR DESCRIPTION
When the kafka module is removed micrometer in the main module cannot be instantiated. Micrometer depends on aspects. The aspects dependency is now moved to the main module. The kafka module can now be safely removed.